### PR TITLE
MELOSYS-2408 - Gjør kontaktopplysnings-felter nullable

### DIFF
--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -190,7 +190,7 @@
       "examples": [
         "810072512"
       ],
-      "pattern": "^\\d{9}$"
+      "pattern": "^\\d{9}$|^$"
     },
     "fnr": {
       "type": "string",

--- a/schema/kontaktopplysninger-post-schema.json
+++ b/schema/kontaktopplysninger-post-schema.json
@@ -12,7 +12,7 @@
   "properties": {
     "kontaktnavn": {
       "$id": "#/properties/kontaktnavn",
-      "type": "string",
+      "type": ["string", "null"],
       "title": "The Kontaktnavn Schema",
       "default": "",
       "examples": [
@@ -23,7 +23,7 @@
     "kontaktorgnr": {
       "title": "The Kontaktorgnr Schema",
       "$id": "#/properties/kontaktorgnr",
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/orgnr"
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-orgnr"
     }
   }
 }


### PR DESCRIPTION
Vi ønsker å kunne lagre kontaktnavn og kontaktorgnr uavnhengig av hverandre. Med andre ord, det skal være mulig å lagre et kontaktnavn uten å lagre et kontaktnr, og omvendt. 