### PR TITLE
MELOSYS-3253 - Sakstyper og behandlingstyper ved plukk skal ikke være liste

### DIFF
--- a/mock_data/oppgaver-plukk/post/oppgaver-plukk-post.json
+++ b/mock_data/oppgaver-plukk/post/oppgaver-plukk-post.json
@@ -1,5 +1,4 @@
 {
-  "oppgavetype": "BEH_SAK_MK",
   "sakstype": "EU_EOS",
   "behandlingstype": "SOEKNAD"
 }

--- a/mock_data/oppgaver-plukk/post/oppgaver-plukk-post.json
+++ b/mock_data/oppgaver-plukk/post/oppgaver-plukk-post.json
@@ -1,5 +1,5 @@
 {
   "oppgavetype": "BEH_SAK_MK",
-  "sakstyper": ["EU_EOS"],
-  "behandlingstyper": ["SOEKNAD"]
+  "sakstype": "EU_EOS",
+  "behandlingstype": "SOEKNAD"
 }

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -281,16 +281,6 @@
       ],
       "pattern": "^(.*)$"
     },
-    "oppgavetype": {
-      "title": "The Oppgavetype schema",
-      "type": ["string", "null"],
-      "examples": ["BEH_SAK_MK", "JFR"],
-      "enum": [
-        "BEH_SAK_MK",
-        "JFR",
-        null
-      ]
-    },
     "periodeID": {
       "type": "integer",
       "title": "The PeriodeID Schema",

--- a/schema/oppgaver-plukk-post-schema.json
+++ b/schema/oppgaver-plukk-post-schema.json
@@ -6,26 +6,18 @@
   "additionalProperties": false,
   "required": [
     "oppgavetype",
-    "sakstyper",
-    "behandlingstyper"
+    "sakstype",
+    "behandlingstype"
   ],
   "properties": {
     "oppgavetype": {
       "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/oppgavetype"
     },
-    "sakstyper": {
-      "type": "array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/sakstype"
-      }
+    "sakstype": {
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/sakstype"
     },
-    "behandlingstyper": {
-      "type":"array",
-      "uniqueItems": true,
-      "items": {
-        "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/behandlingstype"
-      }
+    "behandlingstype": {
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/behandlingstype"
     }
   }
 }

--- a/schema/oppgaver-plukk-post-schema.json
+++ b/schema/oppgaver-plukk-post-schema.json
@@ -5,14 +5,10 @@
   "title": "The Plukk-post Schema",
   "additionalProperties": false,
   "required": [
-    "oppgavetype",
     "sakstype",
     "behandlingstype"
   ],
   "properties": {
-    "oppgavetype": {
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/oppgavetype"
-    },
     "sakstype": {
       "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/sakstype"
     },


### PR DESCRIPTION
Oppgave-API støtter bare en enkelt behandlingstype og en enkelt sakstype.
melosys-web: https://github.com/navikt/melosys-web/pull/753