### PR TITLE
MELOSYS-2406 - Jenkins feiler ved npm install

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-registry=https://npm.pkg.github.com/navikt


### PR DESCRIPTION
Jenkins feiler ved npm install, prøver å hente fra GPR selv om pakker ligger i npm registry. Fjerner unødvendig .npmrc.