### PR TITLE
representantRepresenterer -> representererKode

### DIFF
--- a/mock_data/journalforing-opprett/post/opprett-post.json5
+++ b/mock_data/journalforing-opprett/post/opprett-post.json5
@@ -4,7 +4,7 @@
   "representantID": "",
   "behandlingstypeKode": "SOEKNAD",
   "representantKontaktPerson": null,
-  "representantRepresenterer": "BRUKER",
+  "representererKode": "BRUKER",
   "avsenderID": "30098000492",
   "avsenderNavn": "HEST LILLA",
   "dokumentID": "Dok_ID",

--- a/schema/journalforing-opprett-post-schema.json
+++ b/schema/journalforing-opprett-post-schema.json
@@ -15,7 +15,7 @@
     "arbeidsgiverID",
     "representantID",
     "representantKontaktPerson",
-    "representantRepresenterer",
+    "representererKode",
     "dokumentID",
     "hoveddokumentTittel",
     "vedlegg",
@@ -96,9 +96,9 @@
       "title": "The RepresentantKontaktPerson Schema",
       "default": ""
     },
-    "representantRepresenterer": {
-      "title": "The RepresentantRepresenterer Schema",
-      "$id": "#/properties/representantRepresenterer",
+    "representererKode": {
+      "title": "The RepresentererKode Schema",
+      "$id": "#/properties/representererKode",
       "type": "string",
       "default": "",
       "pattern": "^(.*)$"


### PR DESCRIPTION
Skrivefeil i forrige PR (#131), backend forventer `representererKode` (som har blitt brukt før i andre dto-er)