### PR TITLE
Melosys 3784 luftfart base

### DIFF
--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
@@ -92,6 +92,7 @@
       "trygdeavgiftTrukketGjennomSkattDato": "2018-06-01"
     },
     "maritimtArbeid": [],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["FR"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
@@ -45,7 +45,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -124,6 +124,13 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [
+      {
+        "hjemmebaseNavn": "Dunfjæder",
+        "hjemmebaseLand": "GB",
+        "typeFlyvninger": "NASJONAL"
+      }
+    ],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -124,6 +124,7 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "DE",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -124,6 +124,7 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -124,6 +124,7 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
@@ -100,7 +100,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
@@ -49,7 +49,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
@@ -96,6 +96,7 @@
       "trygdeavgiftTrukketGjennomSkattDato": null
     },
     "maritimtArbeid": [],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["DK", "SE"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -65,7 +65,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": true,
       "arbeidsforholdVikarNavn": "Vikarbyrået AS",
       "vikarOrgnr": "22334455",
-      "flyendePersonellHjemmebase": "Flybasen Int. Airport, ....",
       "kontaktNavn": "Ola Nordmann",
       "kontaktEpost": "ola.nordmann@fullmektigfirma.no",
       "fullmektigFirma": "Advokatfullmektig AS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -124,6 +124,13 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [
+      {
+        "hjemmebaseNavn": "Dunfjæder",
+        "hjemmebaseLand": "GB",
+        "typeFlyvninger": "NASJONAL"
+      }
+    ],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
@@ -45,7 +45,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
@@ -93,6 +93,7 @@
     },
     "maritimtArbeid": [
     ],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["DE"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
@@ -45,7 +45,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
@@ -92,6 +92,7 @@
       "trygdeavgiftTrukketGjennomSkattDato": null
     },
     "maritimtArbeid": [],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["SE"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
@@ -92,6 +92,7 @@
       "trygdeavgiftTrukketGjennomSkattDato": "2018-06-01"
     },
     "maritimtArbeid": [],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["FR"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
@@ -45,7 +45,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
@@ -92,6 +92,7 @@
       "trygdeavgiftTrukketGjennomSkattDato": "2018-06-01"
     },
     "maritimtArbeid": [],
+    "luftfartBase": [],
     "soeknadsland": {
       "landkoder": ["FR"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
@@ -45,7 +45,6 @@
       "arbeidsforholdOpprettholdIHelePerioden": null,
       "arbeidsforholdVikarNavn": null,
       "vikarOrgnr": null,
-      "flyendePersonellHjemmebase": null,
       "kontaktNavn": null,
       "kontaktEpost": null,
       "fullmektigFirma": null,

--- a/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
+++ b/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
@@ -85,6 +85,13 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBase": [
+      {
+        "hjemmebaseNavn": "Dunfjæder",
+        "hjemmebaseLand": "GB",
+        "typeFlyvninger": "NASJONAL"
+      }
+    ],
     "arbeidUtland" : [
       {
         "foretakNavn" : "BMW AG",

--- a/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
+++ b/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
@@ -32,7 +32,6 @@
       "fullmektigFirma" : "Advokatfullmektig AS",
       "kontaktEpost" : "ola.nordmann@fullmektigfirma.no",
       "arbeidsforholdVikarNavn" : "Vikarbyrået AS",
-      "flyendePersonellHjemmebase" : "Flybasen Int. Airport, ....",
       "fullmektigGateadresse" : "Adresseveien 123",
       "arbeidsforholdOpprettholdIHelePerioden" : true,
       "vikarOrgnr" : "22334455",

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -495,6 +495,50 @@
         }
       }
     },
+    "luftfartBase": {
+      "type": "array",
+      "title": "The LuftfartBase Schema",
+      "uniqueItems": true,
+      "items": {
+        "type": "object",
+        "title": "The LuftfartBase Schema",
+        "additionalProperties": false,
+        "required": [
+          "hjemmebaseNavn",
+          "hjemmebaseLand",
+          "typeFlyvninger"
+        ],
+        "properties": {
+          "hjemmebaseNavn": {
+            "type": "string",
+            "title": "The HjemmebaseNavn Schema",
+            "default": "",
+            "examples": [
+              "Hjemmebasens navn"
+            ],
+            "pattern": "^(.+)$"
+          },
+          "hjemmebaseLand": {
+            "type": "string",
+            "title": "The HjemmebaseLand Schema",
+            "default": "",
+            "examples": [
+              "Hjemmebasens land"
+            ],
+            "pattern": "^(.+)$"
+          },
+          "typeFlyvninger": {
+            "type": "string",
+            "title": "The TypeFlyvninger Schema",
+            "enum": ["NASJONAL", "INTERNASJONAL", "BEGGE"],
+            "examples": [
+              "NASJONAL"
+            ],
+            "pattern": "^(.*)$"
+          }
+        }
+      }
+    },
     "soeknadsland": {
       "type": "object",
       "title": "The Soeknadsland Schema",
@@ -1062,6 +1106,7 @@
         "arbeidNorge",
         "selvstendigArbeid",
         "maritimtArbeid",
+        "luftfartBase",
         "soeknadsland",
         "periode"
       ],
@@ -1096,6 +1141,9 @@
         "maritimtArbeid": {
           "$ref": "#/definitions/maritimtArbeid"
         },
+        "luftfartBase": {
+          "$ref": "#/definitions/luftfartBase"
+        },
         "soeknadsland": {
           "$ref": "#/definitions/soeknadsland"
         },
@@ -1120,6 +1168,7 @@
         "arbeidNorge",
         "selvstendigArbeid",
         "maritimtArbeid",
+        "luftfartBase",
         "soeknadsland",
         "periode"
       ],
@@ -1150,6 +1199,9 @@
         },
         "maritimtArbeid": {
           "$ref": "#/definitions/maritimtArbeid"
+        },
+        "luftfartBase": {
+          "$ref": "#/definitions/luftfartBase"
         },
         "soeknadsland": {
           "$ref": "#/definitions/soeknadsland"

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -254,7 +254,6 @@
         "arbeidsforholdOpprettholdIHelePerioden",
         "arbeidsforholdVikarNavn",
         "vikarOrgnr",
-        "flyendePersonellHjemmebase",
         "kontaktNavn",
         "kontaktEpost",
         "fullmektigFirma",
@@ -288,15 +287,6 @@
           "default": "",
           "examples": [
             "22334455"
-          ],
-          "pattern": "^(.*)$"
-        },
-        "flyendePersonellHjemmebase": {
-          "type": ["string","null"],
-          "title": "The Flyendepersonellhjemmebase Schema",
-          "default": "",
-          "examples": [
-            "Flybasen Int. Airport, ...."
           ],
           "pattern": "^(.*)$"
         },

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -491,7 +491,7 @@
       "uniqueItems": true,
       "items": {
         "type": "object",
-        "title": "The LuftfartBase Schema",
+        "title": "The LuftfartBaseItem Schema",
         "additionalProperties": false,
         "required": [
           "hjemmebaseNavn",


### PR DESCRIPTION
Legger til skjema for `luftfartBase` for arbeidssted ombord på fly. Fjerner `flyendePersonellHjemmebase` fra `arbeidNorge`, da denne virker overflødig med nytt skjema.

Har lagt til Francois som reviewer, siden han kjenner denne modellen fra jobb med mottak av elektronisk søknad fra Altinn.