### PR TITLE
Legg til luftfartBaser i sedGrunnlag

### DIFF
--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -102,6 +102,7 @@
         "foretakOrgnr": "967032271"
       }
     ],
+    "luftfartBaser": [],
     "soeknadsland": {
       "landkoder": ["DK"]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
@@ -125,6 +125,7 @@
       "ekstraArbeidsgivere": []
     },
     "maritimtArbeid": [],
+    "luftfartBaser": [],
     "bosted": {
       "intensjonOmRetur": null,
       "antallMaanederINorge": 0,

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -500,7 +500,7 @@
         ],
         "properties": {
           "hjemmebaseNavn": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "The HjemmebaseNavn Schema",
             "default": "",
             "examples": [
@@ -509,7 +509,7 @@
             "pattern": "^(.+)$"
           },
           "hjemmebaseLand": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "The HjemmebaseLand Schema",
             "default": "",
             "examples": [
@@ -518,7 +518,7 @@
             "pattern": "^(.+)$"
           },
           "typeFlyvninger": {
-            "type": "string",
+            "type": ["string", "null"],
             "title": "The TypeFlyvninger Schema",
             "enum": ["NASJONAL", "INTERNASJONAL", "BEGGE"],
             "examples": [

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -1213,6 +1213,7 @@
         "arbeidNorge",
         "selvstendigArbeid",
         "maritimtArbeid",
+        "luftfartBaser",
         "soeknadsland",
         "periode",
         "overgangsregelbestemmelser",
@@ -1246,6 +1247,9 @@
         },
         "maritimtArbeid": {
           "$ref": "#/definitions/maritimtArbeid"
+        },
+        "luftfartBaser": {
+          "$ref": "#/definitions/luftfartBaser"
         },
         "soeknadsland": {
           "$ref": "#/definitions/soeknadsland"


### PR DESCRIPTION
Fikser en tabbe fra #161:

Jeg la feltet `luftfartBaser` til i skjemaene for `behandlingsgrunnlagData` og `soeknadData`, men siden også `sedGrunnlag` extender `behandlingsgrunnlagData` i `melosys-api`, må også denne ha det nye feltet for å validere.