### PR TITLE
MELOSYS-3647 - Legg til felt i vilkår for engelsk fritekstbegrunnelse

### DIFF
--- a/mock_data/vilkaar/post/vilkaar-post.json5
+++ b/mock_data/vilkaar/post/vilkaar-post.json5
@@ -3,6 +3,7 @@
     "vilkaar": "ART12_1_FORUTGAAENDE_MEDLEMSKAP",
     "oppfylt": true,
     "begrunnelseKoder": [],
-    "begrunnelseFritekst": null
+    "begrunnelseFritekst": null,
+    "begrunnelseFritekstEngelsk": null
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-10.json5
+++ b/mock_data/vilkaar/vilkaar-bid-10.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-11.json5
+++ b/mock_data/vilkaar/vilkaar-bid-11.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-12.json5
+++ b/mock_data/vilkaar/vilkaar-bid-12.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-14.json5
+++ b/mock_data/vilkaar/vilkaar-bid-14.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-15.json5
+++ b/mock_data/vilkaar/vilkaar-bid-15.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-16.json5
+++ b/mock_data/vilkaar/vilkaar-bid-16.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-17.json5
+++ b/mock_data/vilkaar/vilkaar-bid-17.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-3.json5
+++ b/mock_data/vilkaar/vilkaar-bid-3.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-4.json5
+++ b/mock_data/vilkaar/vilkaar-bid-4.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-5.json5
+++ b/mock_data/vilkaar/vilkaar-bid-5.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-6.json5
+++ b/mock_data/vilkaar/vilkaar-bid-6.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-7.json5
+++ b/mock_data/vilkaar/vilkaar-bid-7.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/mock_data/vilkaar/vilkaar-bid-9.json5
+++ b/mock_data/vilkaar/vilkaar-bid-9.json5
@@ -3,6 +3,7 @@
     vilkaar: 'FO_883_2004_INNGANGSVILKAAR',
     oppfylt: true,
     begrunnelseKoder: [],
-    begrunnelseFritekst: null
+    begrunnelseFritekst: null,
+    begrunnelseFritekstEngelsk: null,
   }
 ]

--- a/schema/vilkaar-post-schema.json
+++ b/schema/vilkaar-post-schema.json
@@ -14,7 +14,8 @@
       "vilkaar",
       "oppfylt",
       "begrunnelseKoder",
-      "begrunnelseFritekst"
+      "begrunnelseFritekst",
+      "begrunnelseFritekstEngelsk"
     ],
     "properties": {
       "vilkaar": {
@@ -70,6 +71,11 @@
         "examples": [
           "En begrunnelsestekst"
         ],
+        "pattern": "^(.*)$"
+      },
+      "begrunnelseFritekstEngelsk": {
+        "type": ["string", "null"],
+        "title": "The BegrunnelsefritekstEngelsk Schema",
         "pattern": "^(.*)$"
       }
     }

--- a/schema/vilkaar-schema.json
+++ b/schema/vilkaar-schema.json
@@ -12,7 +12,8 @@
       "vilkaar",
       "oppfylt",
       "begrunnelseKoder",
-      "begrunnelseFritekst"
+      "begrunnelseFritekst",
+      "begrunnelseFritekstEngelsk"
     ],
     "properties": {
       "vilkaar": {
@@ -57,6 +58,11 @@
         "examples": [
           "En begrunnelsestekst"
         ],
+        "pattern": "^(.*)$"
+      },
+      "begrunnelseFritekstEngelsk": {
+        "type": ["string", "null"],
+        "title": "The BegrunnelsefritekstEngelsk Schema",
         "pattern": "^(.*)$"
       }
     }


### PR DESCRIPTION
- Gjør det mulig å oppgi en fritekstbegrunnelse til brev, og en fritekstbegrunnelse på engelsk til SED. Dette gjelder for øyeblikket ved sending av anmodning om unntak.