### PR TITLE
Oppdater skjema for familieopplysninger

### DIFF
--- a/mock_data/behandlinger-behandling/behandling-bid-10.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-10.json5
@@ -336,7 +336,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-10.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-10.json5
@@ -335,7 +335,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-11.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-11.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-11.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-11.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-12.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-12.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-12.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-12.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-13.json
+++ b/mock_data/behandlinger-behandling/behandling-bid-13.json
@@ -31,7 +31,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     }

--- a/mock_data/behandlinger-behandling/behandling-bid-13.json
+++ b/mock_data/behandlinger-behandling/behandling-bid-13.json
@@ -31,8 +31,7 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          },
-          "borMedBruker": true
+          }
         }
       ]
     }

--- a/mock_data/behandlinger-behandling/behandling-bid-14.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-14.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-14.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-14.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-15.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-15.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-15.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-15.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-16.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-16.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-16.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-16.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-17.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-17.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-17.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-17.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-3.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-3.json5
@@ -31,7 +31,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "26030537263",
@@ -39,7 +41,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "08029828362",
@@ -47,7 +51,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-3.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-3.json5
@@ -32,8 +32,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true,
-          "fnrAnnenForelder": "08029828362"
+          "alder": 14,
+          "borMedBruker": false,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "17028920377"
         },
         {
           "fnr": "26030537263",
@@ -42,7 +45,10 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
+          "alder": 15,
           "borMedBruker": true,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
           "fnrAnnenForelder": "08029828362"
         },
         {
@@ -52,7 +58,14 @@
             "kode": "EKTE",
             "term": "Ektefelle"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": true,
+          "sivilstand": {
+            "kode": "GIFT",
+            "term": "Gift"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-4.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-4.json5
@@ -631,7 +631,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle til"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-4.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-4.json5
@@ -632,7 +632,14 @@
             "kode": "EKTE",
             "term": "Ektefelle til"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": false,
+          "sivilstand": {
+            "kode": "GLAD",
+            "term": "Gift, lever adskilt"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-5.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-5.json5
@@ -31,7 +31,8 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true
         },
         {
           "fnr": "26030537263",
@@ -39,7 +40,8 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true
         },
         {
           "fnr": "08029828362",
@@ -47,7 +49,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-5.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-5.json5
@@ -32,7 +32,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true
+          "alder": 14,
+          "borMedBruker": false,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "17028920377"
         },
         {
           "fnr": "26030537263",
@@ -41,7 +45,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true
+          "alder": 15,
+          "borMedBruker": true,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "08029828362",
@@ -50,7 +58,14 @@
             "kode": "EKTE",
             "term": "Ektefelle"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": true,
+          "sivilstand": {
+            "kode": "GIFT",
+            "term": "Gift"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-6.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-6.json5
@@ -31,7 +31,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "26030537263",
@@ -39,7 +41,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "08029828362",
@@ -47,7 +51,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-6.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-6.json5
@@ -32,8 +32,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true,
-          "fnrAnnenForelder": "08029828362"
+          "alder": 14,
+          "borMedBruker": false,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "17028920377"
         },
         {
           "fnr": "26030537263",
@@ -42,7 +45,10 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
+          "alder": 15,
           "borMedBruker": true,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
           "fnrAnnenForelder": "08029828362"
         },
         {
@@ -52,7 +58,14 @@
             "kode": "EKTE",
             "term": "Ektefelle"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": true,
+          "sivilstand": {
+            "kode": "GIFT",
+            "term": "Gift"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-7.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-7.json5
@@ -31,7 +31,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "26030537263",
@@ -39,7 +41,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "08029828362",
@@ -47,7 +51,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-7.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-7.json5
@@ -32,8 +32,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true,
-          "fnrAnnenForelder": "08029828362"
+          "alder": 14,
+          "borMedBruker": false,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "17028920377"
         },
         {
           "fnr": "26030537263",
@@ -42,7 +45,10 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
+          "alder": 15,
           "borMedBruker": true,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
           "fnrAnnenForelder": "08029828362"
         },
         {
@@ -52,7 +58,14 @@
             "kode": "EKTE",
             "term": "Ektefelle"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": true,
+          "sivilstand": {
+            "kode": "GIFT",
+            "term": "Gift"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-9.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-9.json5
@@ -31,7 +31,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "26030537263",
@@ -39,7 +41,9 @@
           "relasjonstype": {
             "kode": "BARN",
             "term": "Barn Av"
-          }
+          },
+          "borMedBruker": true,
+          "fnrAnnenForelder": "08029828362"
         },
         {
           "fnr": "08029828362",
@@ -47,7 +51,8 @@
           "relasjonstype": {
             "kode": "EKTE",
             "term": "Ektefelle"
-          }
+          },
+          "borMedBruker": true
         }
       ]
     },

--- a/mock_data/behandlinger-behandling/behandling-bid-9.json5
+++ b/mock_data/behandlinger-behandling/behandling-bid-9.json5
@@ -32,8 +32,11 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
-          "borMedBruker": true,
-          "fnrAnnenForelder": "08029828362"
+          "alder": 14,
+          "borMedBruker": false,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
+          "fnrAnnenForelder": "17028920377"
         },
         {
           "fnr": "26030537263",
@@ -42,7 +45,10 @@
             "kode": "BARN",
             "term": "Barn Av"
           },
+          "alder": 15,
           "borMedBruker": true,
+          "sivilstand": null,
+          "sivilstandGyldighetsperiodeFom": null,
           "fnrAnnenForelder": "08029828362"
         },
         {
@@ -52,7 +58,14 @@
             "kode": "EKTE",
             "term": "Ektefelle"
           },
-          "borMedBruker": true
+          "alder": null,
+          "borMedBruker": true,
+          "sivilstand": {
+            "kode": "GIFT",
+            "term": "Gift"
+          },
+          "sivilstandGyldighetsperiodeFom": "1999-12-31",
+          "fnrAnnenForelder": null
         }
       ]
     },

--- a/mock_data/personer/fnr-17117802280.json5
+++ b/mock_data/personer/fnr-17117802280.json5
@@ -40,5 +40,34 @@
       ],
       "landkode": "UK"
     }
-  }
+  },
+  "familiemedlemmer": [
+    {
+      "fnr": "10100638274",
+      "sammensattNavn": "GIRAFF MAGER",
+      "relasjonstype": {
+        "kode": "BARN",
+        "term": "Barn Av"
+      },
+      "borMedBruker": true
+    },
+    {
+      "fnr": "26030537263",
+      "sammensattNavn": "BUKSE LURVETE",
+      "relasjonstype": {
+        "kode": "BARN",
+        "term": "Barn Av"
+      },
+      "borMedBruker": true
+    },
+    {
+      "fnr": "08029828362",
+      "sammensattNavn": "UTVIKLER OPTIMISTISK",
+      "relasjonstype": {
+        "kode": "EKTE",
+        "term": "Ektefelle"
+      },
+      "borMedBruker": true
+    }
+  ]
 }

--- a/mock_data/personer/fnr-17117802280.json5
+++ b/mock_data/personer/fnr-17117802280.json5
@@ -49,7 +49,11 @@
         "kode": "BARN",
         "term": "Barn Av"
       },
-      "borMedBruker": true
+      "alder": 14,
+      "borMedBruker": false,
+      "sivilstand": null,
+      "sivilstandGyldighetsperiodeFom": null,
+      "fnrAnnenForelder": "17028920377",
     },
     {
       "fnr": "26030537263",
@@ -58,7 +62,11 @@
         "kode": "BARN",
         "term": "Barn Av"
       },
-      "borMedBruker": true
+      "alder": 15,
+      "borMedBruker": true,
+      "sivilstand": null,
+      "sivilstandGyldighetsperiodeFom": null,
+      "fnrAnnenForelder": "08029828362"
     },
     {
       "fnr": "08029828362",
@@ -67,7 +75,14 @@
         "kode": "EKTE",
         "term": "Ektefelle"
       },
-      "borMedBruker": true
+      "alder": null,
+      "borMedBruker": true,
+      "sivilstand": {
+        "kode": "GIFT",
+        "term": "Gift"
+      },
+      "sivilstandGyldighetsperiodeFom": "1999-12-31",
+      "fnrAnnenForelder": null
     }
   ]
 }

--- a/mock_data/personer/fnr-19117220349.json5
+++ b/mock_data/personer/fnr-19117220349.json5
@@ -35,5 +35,16 @@
       "poststed": "OSLO",
       "landkode": "NO"
     }
-  }
+  },
+  "familiemedlemmer": [
+    {
+      "fnr": "30098000492",
+      "sammensattNavn": "LILLA HEST",
+      "relasjonstype": {
+        "kode": "EKTE",
+        "term": "Ektefelle til"
+      },
+      "borMedBruker": true
+    }
+  ]
 }

--- a/mock_data/personer/fnr-19117220349.json5
+++ b/mock_data/personer/fnr-19117220349.json5
@@ -44,7 +44,14 @@
         "kode": "EKTE",
         "term": "Ektefelle til"
       },
-      "borMedBruker": true
+      "alder": null,
+      "borMedBruker": false,
+      "sivilstand": {
+        "kode": "GLAD",
+        "term": "Gift, lever adskilt"
+      },
+      "sivilstandGyldighetsperiodeFom": "1999-12-31",
+      "fnrAnnenForelder": null
     }
   ]
 }

--- a/mock_data/personer/fnr-28106600300.json5
+++ b/mock_data/personer/fnr-28106600300.json5
@@ -31,5 +31,6 @@
       "kode": "NO",
       "term": "Norge"
     }
-  }
+  },
+  "familiemedlemmer": []
 }

--- a/mock_data/personer/fnr-30098000492.json5
+++ b/mock_data/personer/fnr-30098000492.json5
@@ -31,5 +31,6 @@
       "kode": "NO",
       "term": "Norge"
     }
-  }
+  },
+  "familiemedlemmer": []
 }

--- a/schema/behandlinger-behandling-schema.json
+++ b/schema/behandlinger-behandling-schema.json
@@ -963,40 +963,8 @@
             },
             "familiemedlemmer": {
               "$id": "#/properties/saksopplysninger/properties/person/properties/familiemedlemmer",
-              "type": "array",
               "title": "The Familiemedlemmer Schema",
-              "uniqueItems": true,
-              "items": {
-                "$id": "#/properties/saksopplysninger/properties/person/properties/familiemedlemmer/items",
-                "type": "object",
-                "title": "The Familie medlem Schema",
-                "required": [
-                  "fnr",
-                  "sammensattNavn",
-                  "relasjonstype"
-                ],
-                "properties": {
-                  "fnr": {
-                    "title": "The Fnr Schema",
-                    "$id": "#/properties/saksopplysninger/properties/person/properties/familiemedlemmer/items/properties/fnr",
-                    "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/fnr"
-                  },
-                  "sammensattNavn": {
-                    "$id": "#/properties/saksopplysninger/properties/person/properties/familiemedlemmer/items/properties/sammensattNavn",
-                    "type": "string",
-                    "title": "The sammensattNavn schema",
-                    "description": "",
-                    "examples": [
-                      "GIRAFF MAGER"
-                    ]
-                  },
-                  "relasjonstype": {
-                    "title": "The relasjonstype schema",
-                    "$id": "#/properties/saksopplysninger/properties/person/properties/familiemedlemmer/items/properties/relasjonstype",
-                    "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"
-                  }
-                }
-              }
+              "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/familiemedlemmer"
             }
           }
         },

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -276,6 +276,13 @@
         }
       }
     },
+    "nullable-kodeverk": {
+      "title": "The Nullable Kodeverk Schema",
+      "oneOf": [
+        {"type": "null"},
+        {"$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"}
+      ]
+    },
     "landkode": {
       "type": "string",
       "minLength": 2,
@@ -687,7 +694,11 @@
           "fnr",
           "sammensattNavn",
           "relasjonstype",
-          "borMedBruker"
+          "alder",
+          "borMedBruker",
+          "sivilstand",
+          "sivilstandGyldighetsperiodeFom",
+          "fnrAnnenForelder"
         ],
         "properties": {
           "fnr": {
@@ -712,7 +723,7 @@
           "alder": {
             "title": "The Alder Schema",
             "$id": "#/definitions/familiemedlemmer/items/properties/alder",
-            "type": "integer"
+            "type": ["integer", "null"]
           },
           "borMedBruker": {
             "title": "The BorMedBruker Schema",
@@ -721,13 +732,13 @@
           },
           "sivilstand": {
             "title": "The Sivilstand Schema",
-            "$id": "#/definitions/familiemedlemmer/items/properties/borMedBruker",
-            "type": "string"
+            "$id": "#/definitions/familiemedlemmer/items/properties/sivilstand",
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-kodeverk"
           },
           "sivilstandGyldighetsperiodeFom": {
             "title": "The SivilstandGyldighetsperiodeFom Schema",
             "$id": "#/definitions/familiemedlemmer/items/properties/sivilstandGyldighetsperiodeFom",
-            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato"
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-dato"
           },
           "fnrAnnenForelder": {
             "title": "The FnrAnnenForelder Schema",

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -673,6 +673,69 @@
         "OMGJØRINGSVEDTAK",
         "ENDRINGSVEDTAK"
       ]
+    },
+    "familiemedlemmer": {
+      "$id": "#/definitions/familiemedlemmer",
+      "type": "array",
+      "title": "The Familiemedlemmer Schema",
+      "uniqueItems": true,
+      "items": {
+        "$id": "#/definitions/familiemedlemmer/items",
+        "type": "object",
+        "title": "The Familiemedlem Schema",
+        "required": [
+          "fnr",
+          "sammensattNavn",
+          "relasjonstype",
+          "borMedBruker"
+        ],
+        "properties": {
+          "fnr": {
+            "title": "The Fnr Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/fnr",
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/fnr"
+          },
+          "sammensattNavn": {
+            "$id": "#/definitions/familiemedlemmer/items/properties/sammensattNavn",
+            "type": "string",
+            "title": "The SammensattNavn Schema",
+            "description": "",
+            "examples": [
+              "GIRAFF MAGER"
+            ]
+          },
+          "relasjonstype": {
+            "title": "The Relasjonstype Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/relasjonstype",
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"
+          },
+          "alder": {
+            "title": "The Alder Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/alder",
+            "type": "integer"
+          },
+          "borMedBruker": {
+            "title": "The BorMedBruker Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/borMedBruker",
+            "type": "boolean"
+          },
+          "sivilstand": {
+            "title": "The Sivilstand Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/borMedBruker",
+            "type": "string"
+          },
+          "sivilstandGyldighetsperiodeFom": {
+            "title": "The SivilstandGyldighetsperiodeFom Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/sivilstandGyldighetsperiodeFom",
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato"
+          },
+          "fnrAnnenForelder": {
+            "title": "The FnrAnnenForelder Schema",
+            "$id": "#/definitions/familiemedlemmer/items/properties/fnrAnnenForelder",
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-fnr"
+          }
+        }
+      }
     }
   }
 }

--- a/schema/personer-schema.json
+++ b/schema/personer-schema.json
@@ -11,7 +11,8 @@
     "sammensattNavn",
     "personstatus",
     "kjoenn",
-    "foedselsdato"
+    "foedselsdato",
+    "familiemedlemmer"
   ],
   "properties": {
     "fnr": {
@@ -65,6 +66,10 @@
     "midlertidigPostadresse": {
       "$id": "#/properties/midlertidigPostadresse",
       "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/adresse"
+    },
+    "familiemedlemmer": {
+      "$id": "#/properties/familiemedlemmer",
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/familiemedlemmer"
     }
   }
 }


### PR DESCRIPTION
Legger til felter for vurdering av medfølgende barn. Feltene `alder` og `fnrAnnenForelder` er kun relevante for barn, og feltene `sivilstand` og `sivilstandGyldighetsperiodeFom` er kun relevante for ektefelle/samboer/partner, men det har jeg ikke lagd noen validering på.