### PR TITLE
Endre skjema for medfølgende familiemedlemmer

### DIFF
--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [{
       "adresse": {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": null,
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -11,7 +11,7 @@
         {
           "fnr": null,
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
@@ -25,7 +25,7 @@
           "landkode": "BG"
         }
       ],
-      "medfolgendeBarn": [],
+      "medfolgendeFamilie": [],
     },
     "arbeidUtland": [
       {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": null,
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": null
+          "navn": null,
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [
       {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -11,7 +11,7 @@
         {
           "fnr": "31031779459",
           "navn": "BRÅKETE GYNGEHEST",
-          "relasjon": "BARN"
+          "relasjonsrolle": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -7,10 +7,11 @@
           "landkode": "DK"
         }
       ],
-      "medfolgendeBarn": [
+      "medfolgendeFamilie": [
         {
           "fnr": "31031779459",
-          "navn": "BRÅKETE GYNGEHEST"
+          "navn": "BRÅKETE GYNGEHEST",
+          "relasjon": "BARN"
         }
       ]
     },

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [{
       "adresse": {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [{
       "adresse": {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [{
       "adresse": {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
@@ -2,7 +2,7 @@
   "data": {
     "personOpplysninger": {
       "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "arbeidUtland": [{
       "adresse": {

--- a/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
+++ b/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
@@ -121,7 +121,7 @@
           "landkode" : "DK"
         }
       ],
-      "medfolgendeBarn": []
+      "medfolgendeFamilie": []
     },
     "soeknadsland": {
       "landkoder": ["DK"]

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -9,7 +9,7 @@
       "additionalProperties": false,
       "required": [
         "utenlandskIdent",
-        "medfolgendeBarn"
+        "medfolgendeFamilie"
       ],
       "properties": {
         "utenlandskIdent": {
@@ -41,7 +41,7 @@
             }
           }
         },
-        "medfolgendeBarn": {
+        "medfolgendeFamilie": {
           "type": "array",
           "title": "The MedfolgendeBarn Schema",
           "uniqueItems": true,
@@ -50,7 +50,8 @@
             "additionalProperties": false,
             "required": [
               "fnr",
-              "navn"
+              "navn",
+              "relasjon"
             ],
             "properties": {
               "fnr": {
@@ -58,6 +59,10 @@
               },
               "navn": {
                 "type": ["string", "null"]
+              },
+              "relasjon": {
+                "type": "string",
+                "enum": ["BARN"]
               }
             }
           }

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -51,7 +51,7 @@
             "required": [
               "fnr",
               "navn",
-              "relasjon"
+              "relasjonsrolle"
             ],
             "properties": {
               "fnr": {
@@ -60,7 +60,7 @@
               "navn": {
                 "type": ["string", "null"]
               },
-              "relasjon": {
+              "relasjonsrolle": {
                 "type": "string",
                 "enum": ["BARN"]
               }


### PR DESCRIPTION
Endrer `medfolgendeBarn` til `medfolgendeFamilie` etter tilbakemelding på navikt/melosys-api#313, for å legge til rette for gjenbruk med folketrygden. Tenker at vi kanskje ikke ønsker å bruke/speile felles kodeverk for familierelasjoner hvis vi bare er interessert i å skille barn vs ektefelle/samboer/partner, men vet ikke om `relasjon` er et veldig beskrivende navn.