### PR TITLE
Fiks bruk av $id iht spec

### DIFF
--- a/schema/eessi-bucer-schema.json
+++ b/schema/eessi-bucer-schema.json
@@ -10,7 +10,7 @@
   ],
   "properties": {
     "bucer": {
-      "id": "#/properties/bucer",
+      "$id": "#/properties/bucer",
       "type": "array",
       "title": "The Bucer Schema",
       "uniqueItems": true,
@@ -50,7 +50,7 @@
             "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato"
           },
           "seder": {
-            "id": "#/bucer/items/properties/seder",
+            "$id": "#/bucer/items/properties/seder",
             "type": "array",
             "title": "The Seder Schema",
             "uniqueItems": true,

--- a/schema/fagsaker-aktoerer-post-schema.json
+++ b/schema/fagsaker-aktoerer-post-schema.json
@@ -22,7 +22,7 @@
     },
     "databaseID": {
       "title": "The DatabaseID schema",
-      "id": "#/items/properties/aktoerID",
+      "$id": "#/items/properties/aktoerID",
       "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-databaseID"
     },
     "orgnr": {

--- a/schema/journalforing-opprett-post-schema.json
+++ b/schema/journalforing-opprett-post-schema.json
@@ -225,7 +225,7 @@
       ]
     },
     "mottattDato": {
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato",
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato"
     }
   }
 }

--- a/schema/journalforing-tilordne-post-schema.json
+++ b/schema/journalforing-tilordne-post-schema.json
@@ -113,7 +113,7 @@
       ]
     },
     "mottattDato": {
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato",
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/dato"
     }
   }
 }


### PR DESCRIPTION
Endrer feil bruk av `id` i stedet for `$id` iht spec: https://json-schema.org/understanding-json-schema/structuring.html#id + fjerner et par trailing commas.

(Bakgrunnen er at jeg prøver ut et annet JSON schema-bibliotek for backend som er strengere på disse feilene.)