### PR TITLE
Legger til de nye kodeverkene i begrunnelsene fra /kodeverk/melosys-internt/folketrygden

### DIFF
--- a/mock_data/kodeverk-melosys-internt-folketrygden/kodeverk-melosys-internt-folketrygden.json5
+++ b/mock_data/kodeverk-melosys-internt-folketrygden/kodeverk-melosys-internt-folketrygden.json5
@@ -115,6 +115,38 @@
         "kode": "ANSATT_I_MULTINASJONALT_SELSKAP",
         "term": "Arbeider i multinasjonalt selskap"
       }
+    ],
+    "Medfolgende_barn_begrunnelser_ftrl": [
+      {
+        kode: "OVER_18_AR",
+        term: "Personen det søkes for er over 18 år"
+      },
+      {
+        kode: "IKKE_SOEKERS_BARN",
+        term: "Barnet er ikke søkerens eget"
+      },
+      {
+        kode: "MANGLER_OPPLYSNINGER",
+        term: "Mangler opplysninger for å vurdere barnets trygdetilhørighet"
+      }
+    ],
+    "Medfolgende_ektefelle_samboer_begrunnelser_ftrl": [
+      {
+        "kode": "SAMBOER_UTEN_FELLES_BARN",
+        "term": "Samboer uten felles barn"
+      },
+      {
+        "kode": "EGEN_INNTEKT",
+        "term": "Ektefelle/samboer har egen inntekt"
+      },
+      {
+        "kode": "IKKE_TRE_AV_FEM",
+        "term": "Ektefelle/samboer har ikke vært medlem i tre av de siste fem kalenderårene"
+      },
+      {
+        "kode": "MANGLER_OPPLYSNINGER",
+        "term": "Mangler opplysninger for å vurdere ektefelle/samboers trygdetilhørighet"
+      }
     ]
   },
   "InnvilgelsesResultat": [

--- a/schema/kodeverk-melosys-internt-folketrygden-schema.json
+++ b/schema/kodeverk-melosys-internt-folketrygden-schema.json
@@ -29,7 +29,9 @@
       "type": "object",
       "required": [
         "Ftrl_2_8_forutgaaende_trygdetid_begrunnelser",
-        "Ftrl_2_8_naer_tilknytning_norge_begrunnelser"
+        "Ftrl_2_8_naer_tilknytning_norge_begrunnelser",
+        "Medfolgende_barn_begrunnelser_ftrl",
+        "Medfolgende_ektefelle_samboer_begrunnelser_ftrl"
       ],
       "Ftrl_2_8_naer_tilknytning_norge_begrunnelser": {
         "type": "array",
@@ -38,6 +40,18 @@
         }
       },
       "Ftrl_2_8_forutgaaende_trygdetid_begrunnelser": {
+        "type": "array",
+        "items": {
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"
+        }
+      },
+      "Medfolgende_barn_begrunnelser_ftrl": {
+        "type": "array",
+        "items": {
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"
+        }
+      },
+      "Medfolgende_ektefelle_samboer_begrunnelser_ftrl": {
         "type": "array",
         "items": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/kodeverk"


### PR DESCRIPTION
Legger til de nye kodeverkene som en del av begrunnelsene som blir hentet fra internt melosys kodeverk for FTLR. Tenker de hører hjemme der siden de også er begrunnelser.

For saken [MELOSYS-4213](https://jira.adeo.no/browse/MELOSYS-4213). Frontend trenger liste over begrunnelsene for barn og ektefelle/samboer. Siden frontend allerede henter kodeverk fra backend via `/kodeverk/melosys-internt/folketrygden`, legger jeg bare til de nye kodeverkene her.