### PR TITLE
Utenlandske org.nr. er ikke nødvendigvis 9 siffer

### DIFF
--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -149,8 +149,7 @@
             "pattern": "^(.*)$"
           },
           "orgnr": {
-            "title": "The Orgnr Schema",
-            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-orgnr"
+            "type": ["string", "null"]
           },
           "selvstendigNaeringsvirksomhet": {
             "type": "boolean"


### PR DESCRIPTION
Ser at utenlandske orgnr ikke nødvendigvis er 9 siffer, men kan inneholde bokstaver, bindestrek, og være annen lengde enn 9 tegn. Foreslår derfor denne endringen, hvor regex på 9 siffer fjernes for orgnr.

Det skal skape lite/ingen jobb backend i følge Andreas.