### PR TITLE
MELOSYS-4436 - behandlingsresultat.vedtakstype er nullable

### DIFF
--- a/schema/behandlinger-resultat-schema.json
+++ b/schema/behandlinger-resultat-schema.json
@@ -69,7 +69,14 @@
       "pattern": "^(.*)$"
     },
     "vedtakstype": {
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/vedtakstype"
+      "oneOf": [
+        {
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/vedtakstype"
+        },
+        {
+          "type": "null"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Vedtakstypen vil være null om det ikke er fattet vedtak