### PR TITLE
Publiser maven snapshot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches-ignore:
       - 'master'
+  workflow_dispatch:
 
 jobs:
   build:
@@ -36,3 +37,57 @@ jobs:
 
       - name: test
         run: npm run schema
+
+      - name: Versioning
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "VERSION=$(node -pe "require('./package.json').version")-${{ github.sha }}-SNAPSHOT" >> $GITHUB_ENV
+
+      - name: Zip
+        if: github.event_name == 'workflow_dispatch'
+        run: |
+          echo ${{ env.VERSION }} > version.txt
+          npm run clean
+          npm run zipSchema -- ${{ env.VERSION }}
+
+      - name: Upload Maven dependencies
+        uses: actions/upload-artifact@v2
+        if: github.event_name == 'workflow_dispatch'
+        with:
+          name: schema-zip
+          path: |
+            version.txt
+            maven-settings.xml
+            lib/@navikt/melosys-schema-*.zip
+          retention-days: 1
+
+  maven:
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Setup Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: '11'
+
+      - name: Download Maven dependencies
+        uses: actions/download-artifact@v2
+        with:
+          name: schema-zip
+
+      - name: Set release version
+        run: echo "VERSION=$(cat version.txt)" >> $GITHUB_ENV
+
+      - name: Publish to Maven
+        run: |
+          cp "lib/@navikt/melosys-schema-${VERSION}.zip" "melosys-schema-${VERSION}.jar"
+          mvn --settings maven-settings.xml deploy:deploy-file \
+            -Dfile="melosys-schema-${VERSION}.jar" \
+            -DartifactId=melosys-schema \
+            -DgroupId=no.nav.melosys \
+            -Dversion=${VERSION} \
+            -Ddescription="Melosys JSON-schema" \
+            -DrepositoryId=github \
+            -Durl="https://maven.pkg.github.com/${GITHUB_REPOSITORY}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/zipSchema2lib.js
+++ b/scripts/zipSchema2lib.js
@@ -3,9 +3,12 @@ const path = require('path');
 // eslint-disable-next-line node/no-unpublished-require
 const zipdir = require('zip-dir');
 
+const args = process.argv.slice(2);
+const versionArg = args[0];
+
 const SCHEMA_DIR = `${process.cwd()}/schema`;
 const LIB_DIR = `${process.cwd()}/lib`;
-const version = `${process.env.npm_package_version}`;
+const version = versionArg || `${process.env.npm_package_version}`;
 const scope = path.dirname(process.env.npm_package_name);
 const name = path.basename(process.env.npm_package_name);
 const SAVE_DIR = `${LIB_DIR}/${scope}`;


### PR DESCRIPTION
Publiserer snapshot av schemabrancher, slik at det blir enklere å rulle ut melosys-api til testmiljø uten å merge schema først.

Maven-`job`en er hentet fra `publish.yml`.