### PR TITLE
Postboks og tilleggsnavn i adresser

### DIFF
--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
@@ -2,16 +2,23 @@
   "mottaksdato": "2020-03-10",
   "data": {
     "personOpplysninger": {
-      "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
+      "utenlandskIdent": [
+        {
+          "ident": "38288D-A",
+          "landkode": "IT"
+        }
+      ],
       "medfolgendeFamilie": []
     },
     "arbeidPaaLand": {
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -24,7 +31,9 @@
     },
     "foretakUtland": [],
     "oppholdUtland": {
-      "oppholdslandkoder": ["FR"],
+      "oppholdslandkoder": [
+        "FR"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2019-05-31"
@@ -37,9 +46,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Waldemar Thranes gate",
-        "husnummer": "98",
+        "husnummerEtasjeLeilighet": "98",
         "region": null,
+        "postboks": null,
         "postnummer": "O175",
         "poststed": "Oslo",
         "landkode": "NO"
@@ -93,7 +104,9 @@
     "maritimtArbeid": [],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["FR"]
+      "landkoder": [
+        "FR"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -105,7 +118,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,8 +70,10 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
+        "postboks": null,
         "region": "St.Hanshaugen Distrikt",
         "postnummer": "12345",
         "poststed": "Poststeder",
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -137,7 +148,9 @@
       }
     ],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -149,7 +162,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,8 +70,10 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
+        "postboks": null,
         "region": "St.Hanshaugen Distrikt",
         "postnummer": "12345",
         "poststed": "Poststeder",
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,8 +70,10 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
+        "postboks": null,
         "region": "St.Hanshaugen Distrikt",
         "postnummer": "12345",
         "poststed": "Poststeder",
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -131,7 +142,9 @@
     ],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -143,7 +156,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,8 +70,10 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
+        "postboks": null,
         "region": "St.Hanshaugen Distrikt",
         "postnummer": "12345",
         "poststed": "Poststeder",
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -131,7 +142,9 @@
     ],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -143,7 +156,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,8 +70,10 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
+        "postboks": null,
         "region": "St.Hanshaugen Distrikt",
         "postnummer": "12345",
         "poststed": "Poststeder",
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -131,7 +142,9 @@
     ],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -143,7 +156,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
@@ -32,9 +32,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -43,10 +45,12 @@
         },
         {
           "adresse": {
+            "tilleggsnavn": null,
             "landkode": "EE",
             "gatenavn": "Testarbeidsstedgate Testarbeidsstedbygning",
-            "husnummer": null,
+            "husnummerEtasjeLeilighet": null,
             "region": "Testarbeidsstedregion",
+            "postboks": null,
             "postnummer": "Testarbeidsstedpostkode",
             "poststed": "Testarbeidsstedby"
           },
@@ -55,10 +59,12 @@
         {
           "virksomhetNavn": "Testarbeidsstednavn2",
           "adresse": {
+            "tilleggsnavn": null,
             "landkode": "CY",
             "gatenavn": "Testarbeidsstedgate2 Testarbeidsstedbygning2",
-            "husnummer": null,
+            "husnummerEtasjeLeilighet": null,
             "region": null,
+            "postboks": null,
             "postnummer": "3212",
             "poststed": "Testarbeidsstedby2"
           }
@@ -74,9 +80,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -84,7 +92,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -114,10 +124,12 @@
       "intensjonOmRetur": null,
       "antallMaanederINorge": 0,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "landkode": "BE",
         "gatenavn": "Testgate Testbyggnavn",
-        "husnummer": null,
+        "husnummerEtasjeLeilighet": null,
         "region": null,
+        "postboks": null,
         "postnummer": "2121",
         "poststed": "asd"
       }

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
@@ -33,9 +33,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -53,9 +55,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -63,7 +67,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -76,9 +82,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": "Storgården",
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
         "region": "St.Hanshaugen Distrikt",
+        "postboks": "Postboks PB-012",
         "postnummer": "12345",
         "poststed": "Poststeder",
         "landkode": "DE"
@@ -87,7 +95,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -129,7 +140,9 @@
       }
     ],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
@@ -9,9 +9,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -39,9 +41,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": null,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Waldemar Thranes gate",
-        "husnummer": "98",
+        "husnummerEtasjeLeilighet": "98",
         "region": null,
+        "postboks": null,
         "postnummer": "O175",
         "poststed": "Oslo",
         "landkode": "NO"
@@ -84,7 +88,10 @@
     "maritimtArbeid": [],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["DK", "SE"]
+      "landkoder": [
+        "DK",
+        "SE"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -96,7 +103,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -21,9 +21,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -41,9 +43,11 @@
         "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
         "adresse": {
+          "tilleggsnavn": null,
           "gatenavn": "Deutschlandstrasse",
-          "husnummer": "123",
+          "husnummerEtasjeLeilighet": "123",
           "region": "Brandenburger",
+          "postboks": null,
           "postnummer": "3388",
           "poststed": "Berlin",
           "landkode": "DE"
@@ -51,7 +55,9 @@
       }
     ],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DK"],
+      "oppholdslandkoder": [
+        "DK"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2018-06-01"
@@ -64,9 +70,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Gateadressen",
-        "husnummer": "14B",
+        "husnummerEtasjeLeilighet": "14B",
         "region": "St.Hanshaugen Distrikt",
+        "postboks": null,
         "postnummer": "12345",
         "poststed": "Poststeder",
         "landkode": "DE"
@@ -75,7 +83,10 @@
     "selvstendigArbeid": {
       "erSelvstendig": true,
       "selvstendigForetak": [
-        { "orgnr": "910253158", "fortsetterEtterArbeidIUtlandet": true }
+        {
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
+        }
       ]
     },
     "juridiskArbeidsgiverNorge": {
@@ -137,7 +148,9 @@
       }
     ],
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -149,7 +162,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_UTSENDTE_ARBEIDSTAKERE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
@@ -9,9 +9,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -24,7 +26,9 @@
     },
     "foretakUtland": [],
     "oppholdUtland": {
-      "oppholdslandkoder": ["DE"],
+      "oppholdslandkoder": [
+        "DE"
+      ],
       "oppholdsPeriode": {
         "fom": "2017-01-01",
         "tom": "2018-05-31"
@@ -37,9 +41,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Waldemar Thranes gate",
-        "husnummer": "98",
+        "husnummerEtasjeLeilighet": "98",
         "region": null,
+        "postboks": null,
         "postnummer": "O175",
         "poststed": "Oslo",
         "landkode": "NO"
@@ -94,7 +100,9 @@
     ],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["DE"]
+      "landkoder": [
+        "DE"
+      ]
     },
     "periode": {
       "fom": "2019-04-04",
@@ -106,7 +114,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
@@ -9,9 +9,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -24,7 +26,9 @@
     },
     "foretakUtland": [],
     "oppholdUtland": {
-      "oppholdslandkoder": ["SE"],
+      "oppholdslandkoder": [
+        "SE"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2019-05-31"
@@ -37,9 +41,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Waldemar Thranes gate",
-        "husnummer": "98",
+        "husnummerEtasjeLeilighet": "98",
         "region": null,
+        "postboks": null,
         "postnummer": "O175",
         "poststed": "Oslo",
         "landkode": "NO"
@@ -82,7 +88,9 @@
     "maritimtArbeid": [],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["SE"]
+      "landkoder": [
+        "SE"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -94,7 +102,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
@@ -2,16 +2,23 @@
   "mottaksdato": "2020-03-10",
   "data": {
     "personOpplysninger": {
-      "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
+      "utenlandskIdent": [
+        {
+          "ident": "38288D-A",
+          "landkode": "IT"
+        }
+      ],
       "medfolgendeFamilie": []
     },
     "arbeidPaaLand": {
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -24,7 +31,9 @@
     },
     "foretakUtland": [],
     "oppholdUtland": {
-      "oppholdslandkoder": ["FR"],
+      "oppholdslandkoder": [
+        "FR"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2019-05-31"
@@ -37,9 +46,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": null,
-        "husnummer": null,
+        "husnummerEtasjeLeilighet": null,
         "region": null,
+        "postboks": null,
         "postnummer": null,
         "poststed": null,
         "landkode": null
@@ -93,7 +104,9 @@
     "maritimtArbeid": [],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["FR"]
+      "landkoder": [
+        "FR"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -105,7 +118,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
@@ -2,16 +2,23 @@
   "mottaksdato": "2020-03-10",
   "data": {
     "personOpplysninger": {
-      "utenlandskIdent": [{"ident": "38288D-A", "landkode": "IT"}],
+      "utenlandskIdent": [
+        {
+          "ident": "38288D-A",
+          "landkode": "IT"
+        }
+      ],
       "medfolgendeFamilie": []
     },
     "arbeidPaaLand": {
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -24,7 +31,9 @@
     },
     "foretakUtland": [],
     "oppholdUtland": {
-      "oppholdslandkoder": ["FR"],
+      "oppholdslandkoder": [
+        "FR"
+      ],
       "oppholdsPeriode": {
         "fom": "2018-01-01",
         "tom": "2019-05-31"
@@ -37,9 +46,11 @@
       "intensjonOmRetur": true,
       "antallMaanederINorge": 8,
       "oppgittAdresse": {
+        "tilleggsnavn": null,
         "gatenavn": "Waldemar Thranes gate",
-        "husnummer": "98",
+        "husnummerEtasjeLeilighet": "98",
         "region": null,
+        "postboks": null,
         "postnummer": "O175",
         "poststed": "Oslo",
         "landkode": "NO"
@@ -93,7 +104,9 @@
     "maritimtArbeid": [],
     "luftfartBaser": [],
     "soeknadsland": {
-      "landkoder": ["FR"]
+      "landkoder": [
+        "FR"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
@@ -105,7 +118,10 @@
       "erFortsattAnsattEtterOppdraget": null,
       "erDrattPaaEgetInitiativ": null,
       "erErstatningTidligereUtsendte": null,
-      "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   },
   "type": "SØKNAD_A1_YRKESAKTIVE_EØS",

--- a/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
+++ b/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
@@ -1,34 +1,38 @@
 {
-  "data" : {
-    "bosted" : {
-      "intensjonOmRetur" : true,
-      "antallMaanederINorge" : 8,
-      "oppgittAdresse" : {
-        "poststed" : "Poststeder",
-        "postnummer" : "12345",
-        "landkode" : "DE",
-        "husnummer": "1",
+  "data": {
+    "bosted": {
+      "intensjonOmRetur": true,
+      "antallMaanederINorge": 8,
+      "oppgittAdresse": {
+        "tilleggsnavn": null,
+        "postboks": "P.O.Box 1234 Place",
+        "poststed": "Poststeder",
+        "postnummer": "12345",
+        "landkode": "DE",
+        "husnummerEtasjeLeilighet": "1",
         "region": null,
-        "gatenavn" : "Gateadressen"
+        "gatenavn": "Gateadressen"
       }
     },
-    "foretakUtland" : [
+    "foretakUtland": [
       {
         "uuid": "2c5ea4c0-4067-11e9-8bad-9b1deb4d3b7d",
-        "navn" : "EQUINOR DEUTSCHLAND",
-        "orgnr" : "372384726",
+        "navn": "EQUINOR DEUTSCHLAND",
+        "orgnr": "372384726",
         "selvstendigNaeringsvirksomhet": true,
-        "adresse" : {
-          "landkode" : "DE",
-          "region" : "Brandenburger",
-          "husnummer" : "123",
-          "postnummer" : "3388",
-          "poststed" : "Berlin",
-          "gatenavn" : "Deutschlandstrasse"
+        "adresse": {
+          "tilleggsnavn": null,
+          "landkode": "DE",
+          "region": "Brandenburger",
+          "husnummerEtasjeLeilighet": "123",
+          "postboks": null,
+          "postnummer": "3388",
+          "poststed": "Berlin",
+          "gatenavn": "Deutschlandstrasse"
         }
       }
     ],
-    "juridiskArbeidsgiverNorge" : {
+    "juridiskArbeidsgiverNorge": {
       "antallAdmAnsatte": 35,
       "antallAnsatte": 350,
       "antallUtsendte": 35,
@@ -60,22 +64,22 @@
       "erTrukketTrygdeavgift": null,
       "utlArbTilhoererSammeKonsern": null
     },
-    "arbeidsgiversBekreftelse" : {
-      "arbeidsgiverBetalerArbeidsgiveravgift" : true,
-      "arbeidstakerAnsattUnderUtsendelsen" : true,
-      "arbeidsgiverBekrefterUtsendelse" : true,
-      "erstatterArbeidstakerenUtsendte" : false,
-      "trygdeavgiftTrukketGjennomSkatt" : true,
-      "arbeidstakerTidligereUtsendt24Mnd" : false,
-      "trygdeavgiftTrukketGjennomSkattDato" : "2018-01-01"
+    "arbeidsgiversBekreftelse": {
+      "arbeidsgiverBetalerArbeidsgiveravgift": true,
+      "arbeidstakerAnsattUnderUtsendelsen": true,
+      "arbeidsgiverBekrefterUtsendelse": true,
+      "erstatterArbeidstakerenUtsendte": false,
+      "trygdeavgiftTrukketGjennomSkatt": true,
+      "arbeidstakerTidligereUtsendt24Mnd": false,
+      "trygdeavgiftTrukketGjennomSkattDato": "2018-01-01"
     },
-    "maritimtArbeid" : [
+    "maritimtArbeid": [
       {
-        "innretningLandkode" : null,
+        "innretningLandkode": null,
         "innretningstype": null,
-        "flaggLandkode" : "GB",
-        "enhetNavn" : "Snorre Dunfjæder",
-        "fartsomradeKode" : "INNENRIKS",
+        "flaggLandkode": "GB",
+        "enhetNavn": "Snorre Dunfjæder",
+        "fartsomradeKode": "INNENRIKS",
         "territorialfarvann": null,
       }
     ],
@@ -90,9 +94,11 @@
       "fysiskeArbeidssteder": [
         {
           "adresse": {
+            "tilleggsnavn": null,
             "gatenavn": "Adresseveien 123",
-            "husnummer": "123",
+            "husnummerEtasjeLeilighet": "123",
             "region": "Brandenburger",
+            "postboks": null,
             "postnummer": "1234",
             "poststed": "Poststedet",
             "landkode": "DE",
@@ -103,50 +109,55 @@
       "erHjemmekontor": false,
       "erFastArbeidssted": null
     },
-    "selvstendigArbeid" : {
-      "selvstendigForetak" : [
+    "selvstendigArbeid": {
+      "selvstendigForetak": [
         {
-          "orgnr" : "910253158",
-          "fortsetterEtterArbeidIUtlandet" : true
+          "orgnr": "910253158",
+          "fortsetterEtterArbeidIUtlandet": true
         }
       ],
-      "erSelvstendig" : true
+      "erSelvstendig": true
     },
-    "oppholdUtland" : {
-      "oppholdslandkoder" : [
+    "oppholdUtland": {
+      "oppholdslandkoder": [
         "DK"
       ],
-      "studentSemester" : "2018/2019",
-      "studentFinansieringKode" : "LAANEKASSEN",
-      "oppholdsPeriode" : {
-        "fom" : "2018-01-01",
-        "tom" : "2018-06-01"
+      "studentSemester": "2018/2019",
+      "studentFinansieringKode": "LAANEKASSEN",
+      "oppholdsPeriode": {
+        "fom": "2018-01-01",
+        "tom": "2018-06-01"
       },
-      "ektefelleEllerBarnINorge" : true
+      "ektefelleEllerBarnINorge": true
     },
-    "personOpplysninger" : {
-      "utenlandskIdent" : [
+    "personOpplysninger": {
+      "utenlandskIdent": [
         {
-          "ident" : "123456789",
-          "landkode" : "DK"
+          "ident": "123456789",
+          "landkode": "DK"
         }
       ],
       "medfolgendeFamilie": []
     },
     "soeknadsland": {
-      "landkoder": ["DK"]
+      "landkoder": [
+        "DK"
+      ]
     },
     "periode": {
       "fom": "2018-01-02",
       "tom": "2019-05-30"
     },
     "utenlandsoppdraget": {
-        "erUtsendelseForOppdragIUtlandet": null,
-        "erAnsattForOppdragIUtlandet": null,
-        "erFortsattAnsattEtterOppdraget": null,
-        "erDrattPaaEgetInitiativ": null,
-        "erErstatningTidligereUtsendte": null,
-        "samletUtsendingsperiode": { "fom": "2019-02-01", "tom": "2020-02-01" }
+      "erUtsendelseForOppdragIUtlandet": null,
+      "erAnsattForOppdragIUtlandet": null,
+      "erFortsattAnsattEtterOppdraget": null,
+      "erDrattPaaEgetInitiativ": null,
+      "erErstatningTidligereUtsendte": null,
+      "samletUtsendingsperiode": {
+        "fom": "2019-02-01",
+        "tom": "2020-02-01"
+      }
     }
   }
 }

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -738,14 +738,23 @@
       "type": "object",
       "additionalProperties": false,
       "required": [
+        "tilleggsnavn",
         "gatenavn",
-        "husnummer",
-        "region",
+        "husnummerEtasjeLeilighet",
+        "postboks",
         "postnummer",
         "poststed",
+        "region",
         "landkode"
       ],
       "properties": {
+        "tilleggsnavn": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "examples": [
+            "Storgården"
+          ]
+        },
         "gatenavn": {
           "type": ["string", "null"],
           "minLength": 1,
@@ -753,11 +762,18 @@
             "Waldemar Thranes gate"
           ]
         },
-        "husnummer": {
+        "husnummerEtasjeLeilighet": {
           "type": ["string", "null"],
           "minLength": 1,
           "examples": [
             "98"
+          ]
+        },
+        "postboks": {
+          "type": ["string", "null"],
+          "minLength": 1,
+          "examples": [
+            "P.O.Box 1234 Place"
           ]
         },
         "region": {


### PR DESCRIPTION
I forbindelse med overgang til PDL har jeg tenkt at mengden av adresseformater fra PDL konverteres til adresseformater som Melosys kjenner allerede: strukturerte og ustrukturerte adresser (sjekket med fag).

Melosys trenger da nye felter i strukturerte adresser, postboks og tilleggsnavn.

Bør det være slik at disse er `required`? Funksjonelt sett er disse ikke påkrevd, men samtidig har vi vel ingen valgfrie felter
i schema?

Jeg oppdaterer ikke `strukturertAdresse` fordi den forsvinner med PDL (er også duplisering).