### PR TITLE
MELOSYS-4598 - Arbeidsland er ukjente eller alle EØS-land

### DIFF
--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-10.json5
@@ -106,7 +106,8 @@
     "soeknadsland": {
       "landkoder": [
         "FR"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-12.json5
@@ -150,7 +150,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-14.json5
@@ -118,7 +118,8 @@
       "landkoder": [
         "DK",
         "NO",
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-15.json5
@@ -144,7 +144,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-16.json5
@@ -144,7 +144,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-17.json5
@@ -144,7 +144,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-18.json5
@@ -13,7 +13,8 @@
     ],
     "ytterligereInformasjon": "fritekst",
     "soeknadsland": {
-      "landkoder": []
+      "landkoder": [],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2019-01-01",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-2.json5
@@ -142,7 +142,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-3.json5
@@ -91,7 +91,8 @@
       "landkoder": [
         "DK",
         "SE"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-4.json5
@@ -150,7 +150,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-5.json5
@@ -102,7 +102,8 @@
     "soeknadsland": {
       "landkoder": [
         "DE"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2019-04-04",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-6.json5
@@ -90,7 +90,8 @@
     "soeknadsland": {
       "landkoder": [
         "SE"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-7.json5
@@ -106,7 +106,8 @@
     "soeknadsland": {
       "landkoder": [
         "FR"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
+++ b/mock_data/behandlingsgrunnlag/behandlingsgrunnlag-bid-9.json5
@@ -106,7 +106,8 @@
     "soeknadsland": {
       "landkoder": [
         "FR"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
+++ b/mock_data/behandlingsgrunnlag/post/behandlingsgrunnlag-post.json5
@@ -142,7 +142,8 @@
     "soeknadsland": {
       "landkoder": [
         "DK"
-      ]
+      ],
+      "erUkjenteEllerAlleEosLand": false
     },
     "periode": {
       "fom": "2018-01-02",

--- a/mock_data/fagsaker-sok/sok-fnr-17117802280.json5
+++ b/mock_data/fagsaker-sok/sok-fnr-17117802280.json5
@@ -31,9 +31,10 @@
           "fom": "2018-08-01",
           "tom": "2018-12-31"
         },
-        "land": [
-          "GB"
-        ]
+        "land": {
+          "landkoder": ["GB"],
+          "erUkjenteEllerAlleEosLand": false
+        },
       },
       {
         "behandlingID": 9,
@@ -49,9 +50,10 @@
           "kode": "SOEKNAD",
           "term": "Søknad"
         },
-        "land": [
-          "NL"
-        ],
+        "land": {
+          "landkoder": ["NL"],
+          "erUkjenteEllerAlleEosLand": false
+        },
         "opprettetDato": "2019-04-24T06:29:04.559Z",
         "periode": {
           "fom": "2019-04-04",

--- a/mock_data/fagsaker-sok/sok-fnr-19117220349.json5
+++ b/mock_data/fagsaker-sok/sok-fnr-19117220349.json5
@@ -31,9 +31,10 @@
           "fom": "2018-08-01",
           "tom": "2018-12-31"
         },
-        "land": [
-          "GB"
-        ]
+        "land": {
+          "landkoder": ["GB"],
+          "erUkjenteEllerAlleEosLand": false
+        },
       },
       {
         "behandlingID": 10,
@@ -49,9 +50,10 @@
           "kode": "SOEKNAD",
           "term": "Søknad"
         },
-        "land": [
-          "PL"
-        ],
+        "land": {
+          "landkoder": ["PL"],
+          "erUkjenteEllerAlleEosLand": false
+        },
         "opprettetDato": "2019-04-23T07:48:04.676Z",
         "periode": {
           "fom": "2019-02-01",
@@ -72,7 +74,10 @@
           "kode": "SED",
           "term": "SED"
         },
-        "land": [],
+        "land": {
+          "landkoder": [],
+          "erUkjenteEllerAlleEosLand": false
+        },
         "opprettetDato": "2019-05-08T10:26:45.498Z",
         "periode": {
           "fom": "2018-02-01",

--- a/mock_data/fagsaker-sok/sok-fnr-28106600300.json5
+++ b/mock_data/fagsaker-sok/sok-fnr-28106600300.json5
@@ -31,9 +31,10 @@
           "fom": "2018-08-01",
           "tom": "2018-12-31"
         },
-        "land": [
-          "GB"
-        ]
+        "land": {
+          "landkoder": ["GB"],
+          "erUkjenteEllerAlleEosLand": false
+        },
       }
     ]
   }

--- a/mock_data/fagsaker-sok/sok-fnr-30098000492.json5
+++ b/mock_data/fagsaker-sok/sok-fnr-30098000492.json5
@@ -31,9 +31,10 @@
           "fom": "2018-08-01",
           "tom": "2018-12-31"
         },
-        "land": [
-          "GB"
-        ]
+        "land": {
+          "landkoder": ["GB"],
+          "erUkjenteEllerAlleEosLand": false
+        },
       }
     ]
   },
@@ -69,9 +70,10 @@
           "fom": "2018-08-01",
           "tom": "2018-12-31"
         },
-        "land": [
-          "GB"
-        ]
+        "land": {
+          "landkoder": ["GB"],
+          "erUkjenteEllerAlleEosLand": false
+        },
       }
     ]
   }

--- a/mock_data/oppgaver-oversikt/oppgaver-oversikt.json5
+++ b/mock_data/oppgaver-oversikt/oppgaver-oversikt.json5
@@ -66,7 +66,10 @@
         "tom": "2019-08-31"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -104,7 +107,10 @@
         "tom": "2019-08-31"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -142,7 +148,10 @@
         "tom": "2019-08-31"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -180,7 +189,10 @@
         "tom": "2018-01-01"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -218,7 +230,10 @@
         "tom": "2018-01-01"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -256,7 +271,10 @@
         "tom": "2018-01-01"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -294,7 +312,10 @@
         "tom": null
       },
       "prioritet": "HOY",
-      "land": [],
+      "land": {
+        "landkoder": [],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -332,7 +353,10 @@
         "tom": "2018-01-01"
       },
       "prioritet": "HOY",
-      "land": [],
+      "land": {
+        "landkoder": [],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -370,7 +394,10 @@
         "tom": "2018-01-01"
       },
       "prioritet": "HOY",
-      "land": [],
+      "land": {
+        "landkoder": [],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -408,7 +435,10 @@
         "tom": "2019-08-31"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     },
@@ -446,7 +476,10 @@
         "tom": "2019-08-31"
       },
       "prioritet": "HOY",
-      "land": ["NO"],
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      },
       "versjon": 1,
       "ansvarligID": "Z991001"
     }

--- a/schema/behandlingOversikter-definitions.json
+++ b/schema/behandlingOversikter-definitions.json
@@ -54,18 +54,30 @@
           },
           "land": {
             "$id": "#/definitions/behandlingOversikter/items/properties/land",
-            "type": "array",
+            "type": "object",
             "title": "The Land Schema",
-            "uniqueItems": true,
-            "items": {
-              "$id": "#/definitions/behandlingOversikter/items/properties/land/items",
-              "type": "string",
-              "title": "The Items Schema",
-              "default": "",
-              "examples": [
-                "GB"
-              ],
-              "pattern": "^(.*)$"
+            "additionalProperties": false,
+            "required": [
+              "landkoder",
+              "erUkjenteEllerAlleEosLand"
+            ],
+            "properties": {
+              "landkoder": {
+                "uniqueItems": true,
+                "items": {
+                  "$id": "#/definitions/behandlingOversikter/items/properties/land/items",
+                  "type": "string",
+                  "title": "The Items Schema",
+                  "default": "",
+                  "examples": [
+                    "GB"
+                  ],
+                  "pattern": "^(.*)$"
+                }
+              }
+            },
+            "erUkjenteEllerAlleEosLand": {
+              "type": "boolean"
             }
           }
         }

--- a/schema/behandlingOversikter-definitions.json
+++ b/schema/behandlingOversikter-definitions.json
@@ -53,32 +53,7 @@
             "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"
           },
           "land": {
-            "$id": "#/definitions/behandlingOversikter/items/properties/land",
-            "type": "object",
-            "title": "The Land Schema",
-            "additionalProperties": false,
-            "required": [
-              "landkoder",
-              "erUkjenteEllerAlleEosLand"
-            ],
-            "properties": {
-              "landkoder": {
-                "uniqueItems": true,
-                "items": {
-                  "$id": "#/definitions/behandlingOversikter/items/properties/land/items",
-                  "type": "string",
-                  "title": "The Items Schema",
-                  "default": "",
-                  "examples": [
-                    "GB"
-                  ],
-                  "pattern": "^(.*)$"
-                }
-              }
-            },
-            "erUkjenteEllerAlleEosLand": {
-              "type": "boolean"
-            }
+            "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
           }
         }
       }

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -408,23 +408,6 @@
         }
       }
     },
-    "soeknadsland": {
-      "type": "object",
-      "title": "The Soeknadsland Schema",
-      "additionalProperties": false,
-      "required": [
-        "landkoder",
-        "erUkjenteEllerAlleEosLand"
-      ],
-      "properties": {
-        "landkoder": {
-          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/landkoder"
-        },
-        "erUkjenteEllerAlleEosLand": {
-          "type": ["boolean"]
-        }
-      }
-    },
     "arbeidsgiversBekreftelse": {
       "type": "object",
       "additionalProperties": false,
@@ -801,7 +784,7 @@
           "$ref": "#/definitions/luftfartBaser"
         },
         "soeknadsland": {
-          "$ref": "#/definitions/soeknadsland"
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
         },
         "periode": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"
@@ -868,7 +851,7 @@
           "$ref": "#/definitions/luftfartBaser"
         },
         "soeknadsland": {
-          "$ref": "#/definitions/soeknadsland"
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
         },
         "periode": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"
@@ -926,7 +909,7 @@
           "$ref": "#/definitions/luftfartBaser"
         },
         "soeknadsland": {
-          "$ref": "#/definitions/soeknadsland"
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
         },
         "periode": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"
@@ -979,7 +962,7 @@
           "$ref": "#/definitions/luftfartBaser"
         },
         "soeknadsland": {
-          "$ref": "#/definitions/soeknadsland"
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
         },
         "periode": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"

--- a/schema/behandlingsgrunnlag-definitions.json
+++ b/schema/behandlingsgrunnlag-definitions.json
@@ -413,11 +413,15 @@
       "title": "The Soeknadsland Schema",
       "additionalProperties": false,
       "required": [
-        "landkoder"
+        "landkoder",
+        "erUkjenteEllerAlleEosLand"
       ],
       "properties": {
         "landkoder": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/landkoder"
+        },
+        "erUkjenteEllerAlleEosLand": {
+          "type": ["boolean"]
         }
       }
     },

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -661,7 +661,7 @@
         "FTRL"
       ]
     },
-    "soeknadsland": {
+    "soeknadsland": {
       "type": "object",
       "title": "The Soeknadsland Schema",
       "additionalProperties": false,

--- a/schema/definitions-schema.json
+++ b/schema/definitions-schema.json
@@ -661,6 +661,23 @@
         "FTRL"
       ]
     },
+    "soeknadsland": {
+      "type": "object",
+      "title": "The Soeknadsland Schema",
+      "additionalProperties": false,
+      "required": [
+        "landkoder",
+        "erUkjenteEllerAlleEosLand"
+      ],
+      "properties": {
+        "landkoder": {
+          "$ref": "#/definitions/landkoder"
+        },
+        "erUkjenteEllerAlleEosLand": {
+          "type": ["boolean"]
+        }
+      }
+    },
     "strukturertAdresse": {
       "type": "object",
       "additionalProperties": false,

--- a/schema/oppgaver-definitions.json
+++ b/schema/oppgaver-definitions.json
@@ -160,19 +160,31 @@
         },
         "land": {
           "$id": "#/definitions/saksbehandlingitem/properties/land",
-          "type": "array",
+          "type": "object",
           "title": "The Land Schema",
-          "uniqueItems": true,
-          "additionalItems": false,
-          "items": {
-            "$id": "",
-            "type": "string",
-            "title": "The Landkode item Schema",
-            "default": "",
-            "examples": [
-              "NO"
-            ],
-            "pattern": "^(.*)$"
+          "additionalProperties": false,
+          "required": [
+            "landkoder",
+            "erUkjenteEllerAlleEosLand"
+          ],
+          "properties": {
+            "landkoder": {
+              "uniqueItems": true,
+              "additionalItems": false,
+              "items": {
+                "$id": "",
+                "type": "string",
+                "title": "The Landkode item Schema",
+                "default": "",
+                "examples": [
+                  "NO"
+                ],
+                "pattern": "^(.*)$"
+              }
+            },
+            "erUkjenteEllerAlleEosLand": {
+              "type": "boolean"
+            }
           }
         },
         "versjon": {

--- a/schema/oppgaver-definitions.json
+++ b/schema/oppgaver-definitions.json
@@ -159,33 +159,7 @@
           "pattern": "^(.*)$"
         },
         "land": {
-          "$id": "#/definitions/saksbehandlingitem/properties/land",
-          "type": "object",
-          "title": "The Land Schema",
-          "additionalProperties": false,
-          "required": [
-            "landkoder",
-            "erUkjenteEllerAlleEosLand"
-          ],
-          "properties": {
-            "landkoder": {
-              "uniqueItems": true,
-              "additionalItems": false,
-              "items": {
-                "$id": "",
-                "type": "string",
-                "title": "The Landkode item Schema",
-                "default": "",
-                "examples": [
-                  "NO"
-                ],
-                "pattern": "^(.*)$"
-              }
-            },
-            "erUkjenteEllerAlleEosLand": {
-              "type": "boolean"
-            }
-          }
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/soeknadsland"
         },
         "versjon": {
           "$id": "#/definitions/saksbehandlingitem/properties/versjon",


### PR DESCRIPTION
Begynt å se på MELOSYS-4598.

Ved arbeid i flere land, ønskes det at man skal kunne krysse av i menypunkt for at land er enten ukjent eller alle EØS-land  ([skisse](https://www.figma.com/file/7valEmRFMgUIh4MIh7N0SC/Sidemeny?node-id=3581%3A1)). Dersom det velges alle/ukjente land, må man også kunne se det i `land`-feltet på oppgaveoversikten på forsiden og når man søker etter sak.