### PR TITLE
MELOSYS-4647 - Endre periode ved godkjenning av unntaksperioder

### DIFF
--- a/mock_data/saksflyt-unntaksperioder-godkjenn/post/saksflyt-unntaksperioder-godkjenn-post.json5
+++ b/mock_data/saksflyt-unntaksperioder-godkjenn/post/saksflyt-unntaksperioder-godkjenn-post.json5
@@ -1,4 +1,8 @@
 {
   varsleUtland: true,
-  fritekst: "Fritekst"
+  fritekst: "Fritekst",
+  endretPeriode: {
+    fom: "2014-03-12",
+    tom: "2016-03-12"
+  }
 }

--- a/mock_data/saksflyt-unntaksperioder-godkjenn/post/saksflyt-unntaksperioder-godkjenn-post.json5
+++ b/mock_data/saksflyt-unntaksperioder-godkjenn/post/saksflyt-unntaksperioder-godkjenn-post.json5
@@ -4,5 +4,6 @@
   endretPeriode: {
     fom: "2014-03-12",
     tom: "2016-03-12"
-  }
+  },
+  lovvalgsbestemmelse: "FO_883_2004_ART13_1A"
 }

--- a/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
+++ b/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
@@ -18,7 +18,14 @@
       "type": ["string", "null"]
     },
     "endretPeriode": {
-      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-periode"
+      "oneOf": [
+        {
+          "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/periode"
+        },
+        {
+          "type": "null"
+        }
+      ]
     },
     "lovvalgsbestemmelse": {
       "type": "string"

--- a/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
+++ b/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
@@ -7,7 +7,8 @@
   "required": [
     "varsleUtland",
     "fritekst",
-    "endretPeriode"
+    "endretPeriode",
+    "lovvalgsbestemmelse"
   ],
   "properties": {
     "varsleUtland": {
@@ -18,6 +19,9 @@
     },
     "endretPeriode": {
       "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-periode"
+    },
+    "lovvalgsbestemmelse": {
+      "type": "string"
     }
   }
 }

--- a/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
+++ b/schema/saksflyt-unntaksperioder-godkjenn-post-schema.json
@@ -6,7 +6,8 @@
   "additionalProperties": false,
   "required": [
     "varsleUtland",
-    "fritekst"
+    "fritekst",
+    "endretPeriode"
   ],
   "properties": {
     "varsleUtland": {
@@ -14,6 +15,9 @@
     },
     "fritekst": {
       "type": ["string", "null"]
+    },
+    "endretPeriode": {
+      "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-periode"
     }
   }
 }


### PR DESCRIPTION
Skal sende periode for endring av godkjent unntaksperiode direkte til endepunkt, i stedet for å endre perioden gjennom lovvalgsperiode-endepunkt som gjøres i dag.