### PR TITLE
Melosys 4597 land utvidet med landkoder ukjente alle

### DIFF
--- a/mock_data/fagsaker-opprett/post/fagsaker-opprett-post.json5
+++ b/mock_data/fagsaker-opprett/post/fagsaker-opprett-post.json5
@@ -7,7 +7,10 @@
         fom: "2014-03-12",
         tom: "2015-03-12"
       },
-      "land": ["NO"]
+      "land": {
+        "landkoder": ["NO"],
+        "erUkjenteEllerAlleEosLand": false
+      }
     },
     "skalTilordnes": true,
     "oppgaveID": "1234"

--- a/mock_data/journalforing-opprett/post/opprett-post.json5
+++ b/mock_data/journalforing-opprett/post/opprett-post.json5
@@ -25,9 +25,10 @@
       "fom": "2018-01-01",
       "tom": "2019-03-02"
     },
-    "land": [
-      "NO"
-    ]
+    "land": {
+      "landkoder": ["NO"],
+      "erUkjenteEllerAlleEosLand": false
+    }
   },
   "skalTilordnes": false,
   "ikkeSendForvaltingsmelding": false,

--- a/schema/fagsaker-opprett-post-schema.json
+++ b/schema/fagsaker-opprett-post-schema.json
@@ -34,10 +34,25 @@
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/nullable-periode"
         },
         "land": {
-          "type": "array",
-          "uniqueItems": true,
-          "items": {
-            "type": "string"
+          "type": "object",
+          "title": "The Land Schema",
+          "additionalProperties": false,
+          "required": [
+            "landkoder",
+            "erUkjenteEllerAlleEosLand"
+          ],
+          "properties": {
+            "landkoder": {
+              "type": "array",
+              "title": "The Landkoder Schema",
+              "uniqueItems": true,
+              "items": {
+                "type": "string"
+              }
+            },
+            "erUkjenteEllerAlleEosLand": {
+              "type": "boolean"
+            }
           }
         }
       }

--- a/schema/journalforing-opprett-post-schema.json
+++ b/schema/journalforing-opprett-post-schema.json
@@ -139,19 +139,40 @@
         },
         "land": {
           "$id": "#/properties/fagsak/properties/land",
-          "type": "array",
+          "type": "object",
           "title": "The Land Schema",
-          "uniqueItems": true,
-          "items": {
-            "$id": "#/properties/fagsak/properties/land/items",
-            "type": "string",
-            "title": "The Items Schema",
-            "default": "",
-            "examples": [
-              "NO",
-              "ES"
-            ],
-            "pattern": "^(.*)$"
+          "additionalProperties": false,
+          "required": [
+            "landkoder",
+            "erUkjenteEllerAlleEosLand"
+          ],
+          "properties": {
+            "landkoder": {
+              "$id": "#/properties/fagsak/properties/land/properties/landkoder",
+              "type": "array",
+              "title": "The Landkoder Schema",
+              "uniqueItems": true,
+              "items": {
+                "$id": "#/properties/fagsak/properties/land/properties/landkoder/items",
+                "type": "string",
+                "title": "The Items Schema",
+                "default": "",
+                "examples": [
+                  "NO",
+                  "ES"
+                ],
+                "pattern": "^(.*)$"
+              }
+            },
+            "erUkjenteEllerAlleEosLand": {
+              "$id": "#/properties/fagsak/properties/land/properties/erUkjenteEllerAlleEosLand",
+              "type": "boolean",
+              "title": "The ErUkjenteEllerAlleEosLand Schema",
+              "default": false,
+              "examples": [
+                true
+              ]
+            }
           }
         }
       }


### PR DESCRIPTION
Oppdatert schema nå som land i opprett(Ny)Sak er utvidet med `erUkjenteEllerAlleEosLand`