### PR TITLE
Felles format på fritekstvariabler

### DIFF
--- a/mock_data/saksflyt-vedtak-fatt/post/saksflyt-vedtak-fatt-ftrl-post.json5
+++ b/mock_data/saksflyt-vedtak-fatt/post/saksflyt-vedtak-fatt-ftrl-post.json5
@@ -1,9 +1,9 @@
 {
   "behandlingsresultatTypeKode": "FASTSATT_LOVVALGSLAND",
-  "fritekstInnledning": "Fritekst innledning",
-  "fritekstBegrunnelse": "Fritekst begrunnelse",
-  "fritekstEktefelle": "Fritekst ektefelle",
-  "fritekstBarn": "Fritekst barn",
+  "innledningFritekst": "Fritekst innledning",
+  "begrunnelseFritekst": "Fritekst begrunnelse",
+  "ektefelleFritekst": "Fritekst ektefelle",
+  "barnFritekst": "Fritekst barn",
   "vedtakstype": "FØRSTEGANGSVEDTAK",
   "kopiMottakere": null
 }

--- a/schema/saksflyt-vedtak-fatt-definitions.json
+++ b/schema/saksflyt-vedtak-fatt-definitions.json
@@ -67,10 +67,10 @@
       "required": [
         "behandlingsresultatTypeKode",
         "vedtakstype",
-        "fritekstInnledning",
-        "fritekstBegrunnelse",
-        "fritekstEktefelle",
-        "fritekstBarn",
+        "innledningFritekst",
+        "begrunnelseFritekst",
+        "ektefelleFritekst",
+        "barnFritekst",
         "kopiMottakere"
       ],
       "properties": {
@@ -80,16 +80,16 @@
         "vedtakstype": {
           "$ref": "http://melosys.nav.no/schemas/definitions-schema.json#/definitions/vedtakstype"
         },
-        "fritekstInnledning": {
+        "innledningFritekst": {
           "type": ["string", "null"]
         },
-        "fritekstBegrunnelse": {
+        "begrunnelseFritekst": {
           "type": ["string", "null"]
         },
-        "fritekstEktefelle": {
+        "ektefelleFritekst": {
           "type": ["string", "null"]
         },
-        "fritekstBarn": {
+        "barnFritekst": {
           "type": ["string", "null"]
         },
         "kopiMottakere": {


### PR DESCRIPTION
Var feil variabelnavn i fritekst i storbritannia-brev. Endret alle disse til å ha samme format for å rette opp og unngå samme feil i fremtiden.